### PR TITLE
테스트를 위한 wraper 클래스 제거 및 parser가 요구하는 형태로 변환

### DIFF
--- a/GeneratorUtil.py
+++ b/GeneratorUtil.py
@@ -1,0 +1,22 @@
+from typing import Generator
+
+
+def take(stream: Generator[any, any, None], m: int):
+    if m > 0:
+        m -= 1
+        for i, next in enumerate(stream):
+            yield (next)
+            if i >= m:
+                break
+
+
+def last(stream: Generator[any, any, None]):
+    for i in stream:
+        pass
+    yield i
+
+
+def filterIsType(stream: Generator[any, any, None], cls: any):
+    for i in stream:
+        if type(i) == cls:
+            yield i

--- a/SerialParserTest.py
+++ b/SerialParserTest.py
@@ -1,0 +1,29 @@
+import unittest
+from ParserCoroutine import flatten, flatmap_parse, ParserMessage, ImutablePainState
+from SerialWrapper import read_serial
+from mock import MagicMock
+from serial import Serial
+from GeneratorUtil import take, last, filterIsType
+
+
+class SerialParserTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.serial = MagicMock(spec=Serial)
+
+    def test_serial_mock(self):
+        self.serial.read.return_value = b"test"
+        self.assertEqual(b"test", self.serial.read())
+
+    def test_basic_parse(self):
+        expected = [ImutablePainState()]
+        self.serial.read.return_value = b"\0020\0000\0000\000"
+
+        stream = read_serial(self.serial)
+        stream = take(stream, 1)
+        stream = flatten(stream)
+        stream = flatmap_parse(stream)
+        stream = filterIsType(stream, ImutablePainState)
+
+        result = list(stream)
+
+        self.assertEqual(expected, result)

--- a/SerialWrapper.py
+++ b/SerialWrapper.py
@@ -1,44 +1,7 @@
 import serial
 import random
 
-class SerialWrapper:
-    def __init__(self, portname : str):
-        self.portname = portname
-    
-    def __enter__(self):
-        self._read_debug = self.__read_debug()
-        #next(self._read_debug)
-        if self.portname == 'debug':
-            self.read = self._read
-            return self
-        else:
-            self._ser = serial.Serial(port = self.portname)
-            self.read = self._ser.read
-            self.read_all = self._ser.read_all
-            self.read_until = self._ser.read_until
-            self._ser.flush()
-        return self
 
-    def __exit__(self, type, value, traceback):
-        if self.portname != 'debug':
-            self._ser.flush()
-            self._ser.close()
-
-    def __read_debug(self):
-        def generate():
-            retval = [0] * 7
-            retval[0] = 2
-            retval[1] = b'0'[0] + random.randint(0,1)
-            retval[2] = random.randint(0,3)
-            retval[3] = b'0'[0] + random.randint(0,1)
-            retval[4] = random.randint(0,50)
-            retval[5] = b'0'[0] + random.randint(0,1)
-            retval[6] = random.randint(0,100)
-            
-            return bytes(retval)
-        while True:
-            for output in generate():
-                yield output
-
-    def _read(self):
-        return next(self._read_debug)
+def read_serial(serial: serial.Serial):
+    while True:
+        yield serial.read()


### PR DESCRIPTION
# 해결하려는 문제
* 최신 parser는 send 방식이 아닌 generator 를 요구함.

# 어떻게 해결했나요?
* wrapper class 제거 및 유닛 테스트에서는 mock 사용
* generator 생성 코드 추가